### PR TITLE
Permissão para cpf com 9 dígitos

### DIFF
--- a/src/Pessoa.php
+++ b/src/Pessoa.php
@@ -116,7 +116,7 @@ class Pessoa implements PessoaContract
     public function setDocumento($documento)
     {
         $documento = substr(Util::onlyNumbers($documento), -14);
-        if (!in_array(strlen($documento), [10, 11, 14, 0])) {
+        if (!in_array(strlen($documento), [9, 10, 11, 14, 0])) {
             throw new \Exception('Documento inválido');
         }
         $this->documento = $documento;


### PR DESCRIPTION
Corrigido permissão para cpf com 9 dígitos. Ex: 1.123.123-82