### PR TITLE
Ajuste na geração de arquivo remessa CNAB400 Banrisul

### DIFF
--- a/src/Cnab/Remessa/Cnab400/Banco/Banrisul.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Banrisul.php
@@ -307,7 +307,7 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         $this->add(350, 351, Util::formatCnab('X', $boleto->getPagador()->getUf(), 2));
         $this->add(352, 355, Util::formatCnab('9', 0, 3));
         $this->add(356, 357, '');
-        $this->add(358, 369, '00');
+        $this->add(358, 369, '000000000000');
         $this->add(370, 371, Util::formatCnab('9', $boleto->getDiasProtesto($boleto->getDiasBaixaAutomatica()), 2));
         $this->add(372, 394, '');
         $this->add(395, 400, Util::formatCnab('9', $this->iRegistros + 1, 6));


### PR DESCRIPTION
O campo não estava sendo preenchido com os zeros.
O campo possui 12 caracteres e estava preenchido com "00".
No arquivo ficava da seguinte forma: "          00".
Documentação do campo: Campo numérico (com zeros à esquerda) opcional.
No envio do arquivo ao banco, recebi a seguinte mensagem de erro ao registrar: 
30 - Desconto a conceder não confere: "Instrução de desconto inválida" ou "Taxa ou valor inválido"