### PR TITLE
Campo "nosso número" do BB com 17 digitos não possui digito verificador

### DIFF
--- a/src/Boleto/Banco/Bb.php
+++ b/src/Boleto/Banco/Bb.php
@@ -150,7 +150,7 @@ class Bb extends AbstractBoleto implements BoletoContract
     public function getNossoNumeroBoleto()
     {
         $nn = $this->getNossoNumero() . CalculoDV::bbNossoNumero($this->getNossoNumero());
-        return strlen($nn) <= 17 ? substr_replace($nn, '-', -1, 0) : $nn;
+        return strlen($nn) < 17 ? substr_replace($nn, '-', -1, 0) : $nn;
     }
 
     /**


### PR DESCRIPTION
O campo "nosso número" do BB para convênio de 7 posições (nosso número de 17 digitos) possui o seguinte formato (vide anexo IX da [documentação do BB](https://github.com/newerton/docs-boleto-remessa/blob/master/BB/Especificacao_Boleto_Jan_2016.pdf)):

> CCCCCCCNNNNNNNNNN convênios com numeração acima de 1.000.000, onde:
> "C" - é o número do convênio fornecido pelo Banco (número fixo e não pode ser
> alterado)
> "N" - é um sequencial atribuído pelo cliente

Nesse caso, o campo "nosso número" possui 17 digitos e não possui o digito verificador.

Essa PR não afeta os outros casos (anexos VII e VIII) pois em ambos os casos o "nosso número" possui 11 digitos + 1 digito verificador.